### PR TITLE
AM: decrypt-as-str assumes UTF-8, just like encrypt

### DIFF
--- a/src/lock_key/core.clj
+++ b/src/lock_key/core.clj
@@ -7,7 +7,8 @@
    [lock-key.private.core :as private]
    [base64-clj.core :as base64])
   (:import
-    [javax.crypto Cipher]))
+   [javax.crypto Cipher]
+   [java.nio.charset Charset]))
 
 (defn encrypt
   "Symmetrically encrypts value with encryption-key, such that it can be
@@ -65,7 +66,7 @@
   ;; We encoded strings assuming UTF-8, irrepspective of the
   ;; locale. So to prevent surprises assume the bytes here are also
   ;; UTF-8.
-  (String. (decrypt value encryption-key) utf-8))
+  (String. (decrypt value encryption-key) ^Charset utf-8))
 
 (defn encrypt-as-base64
   "Symmetrically encrypts value with encryption-key, returning a base64 encoded string, such that it can be

--- a/test/lock_key/core_test.clj
+++ b/test/lock_key/core_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer :all]))
 
 (def secret "test key")
-(def value "test value")
+(def value "test value = 10€, süß")
 
 (deftest test-encrypt
   (is (not= value  (String. (encrypt value secret))))
@@ -15,6 +15,7 @@
   (is (thrown? Exception (encrypt value ""))))
 
 (deftest test-decrypt
+  ;; FIXME: this will fail with default charset other than utf-8:
   (is (= value (String. (decrypt (encrypt value secret) secret))))
   (is (private/byte-array? (decrypt (encrypt value secret) secret)))
   (is (thrown? Exception (decrypt :invalid secret)))
@@ -33,6 +34,8 @@
   (is (thrown? Exception (encrypt-as-base64 value ""))))
 
 (deftest test-decrypt-from-base64
+  ;; This could fail in 1.4.1 with the default charset other than
+  ;; utf-8:
   (is (= value (decrypt-from-base64 (encrypt-as-base64 value secret) secret)))
   (is (thrown? Exception (decrypt-from-base64 :invalid secret)))
   (is (thrown? Exception (decrypt-from-base64 (encrypt-as-base64 value secret) :invalid))))


### PR DESCRIPTION
This change makes encrypt-as-base64 -> decrypt-from-base64
round trip work with default charsets other than utf-8.
